### PR TITLE
feat: added 1.19.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,14 +24,14 @@ repositories {
 }
 
 dependencies {
-    compileOnly "org.spigotmc:spigot-api:1.19.2-R0.1-SNAPSHOT"
+    compileOnly "org.spigotmc:spigot-api:1.19.3-R0.1-SNAPSHOT"
     compileOnly "dev.dejvokep:boosted-yaml-spigot:1.3"
     compileOnly "org.apache.commons:commons-configuration2:2.8.0"
-    compileOnly "com.viaversion:viaversion:4.4.1"
+    compileOnly "com.viaversion:viaversion:4.5.1"
     compileOnly "org.apache.logging.log4j:log4j-core:2.19.0"
 
     implementation "org.bstats:bstats-bukkit:3.0.0"
-    implementation "com.github.retrooper.packetevents:spigot:2.0.0-20221209.211024-75"
+    implementation "com.github.retrooper.packetevents:spigot:2.0.0-SNAPSHOT"
 }
 
 tasks {

--- a/src/main/java/com/github/kaspiandev/antipopup/ViaHook.java
+++ b/src/main/java/com/github/kaspiandev/antipopup/ViaHook.java
@@ -12,7 +12,7 @@ public class ViaHook {
     public ViaHook() {
         var viaProtocolManager = Via.getManager().getProtocolManager();
         Protocol<?, ?, ?, ?> protocol = viaProtocolManager.getProtocol(
-                ProtocolVersion.v1_19_1, ProtocolVersion.v1_19);
+                ProtocolVersion.v1_19_3, ProtocolVersion.v1_19);
 
         if (protocol == null) return;
 

--- a/src/main/java/com/github/kaspiandev/antipopup/listeners/PacketEventsListener.java
+++ b/src/main/java/com/github/kaspiandev/antipopup/listeners/PacketEventsListener.java
@@ -6,6 +6,7 @@ import com.github.retrooper.packetevents.event.PacketListenerPriority;
 import com.github.retrooper.packetevents.event.PacketSendEvent;
 import com.github.retrooper.packetevents.protocol.chat.message.ChatMessage;
 import com.github.retrooper.packetevents.protocol.chat.message.ChatMessage_v1_19_1;
+import com.github.retrooper.packetevents.protocol.chat.message.ChatMessage_v1_19_3;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerChatMessage;
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerServerData;
@@ -33,7 +34,7 @@ public class PacketEventsListener extends PacketListenerAbstract {
             serverData.setEnforceSecureChat(true);
         }
         if (event.getPacketType() == PacketType.Play.Server.CHAT_MESSAGE
-                    && AntiPopup.config.getBoolean("strip-signature", true)) {
+                && AntiPopup.config.getBoolean("strip-signature", true)) {
             WrapperPlayServerChatMessage chatMessage = new WrapperPlayServerChatMessage(event);
             ChatMessage message = chatMessage.getMessage();
             if (message instanceof ChatMessage_v1_19_1 v1_19_1) {
@@ -43,9 +44,16 @@ public class PacketEventsListener extends PacketListenerAbstract {
                 v1_19_1.setSenderUUID(new UUID(0L, 0L));
                 v1_19_1.setPreviousSignature(null);
             }
+            if (message instanceof ChatMessage_v1_19_3 v1_19_3) {
+                // We wanna trick the system by giving it random crap
+                v1_19_3.setSignature(new byte[0]);
+                v1_19_3.setSalt(0);
+                v1_19_3.setSenderUUID(new UUID(0L, 0L));
+                v1_19_3.setSignature(null);
+            }
         }
         if (event.getPacketType() == PacketType.Play.Server.PLAYER_CHAT_HEADER
-                    && AntiPopup.config.getBoolean("dont-send-header", true)) {
+                && AntiPopup.config.getBoolean("dont-send-header", true)) {
             event.setCancelled(true);
         }
     }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -11,6 +11,7 @@ softdepend:
   - ViaRewind
   - Geyser-Spigot
 authors: [ Kaspian ]
+contributors: [ Aitooor ]
 description: A plugin that removed annoying unsafe server popup.
 libraries:
   - "dev.dejvokep:boosted-yaml-spigot:1.3"


### PR DESCRIPTION
# Added 1.19.3 version support
- Fix Pom Spigot and Viaversion versions
- Change PacketEventsListener and ViaHook
- You need to re publish to maven local the PacketEvents lib to branch called 2.0 to work fine to you

Video example on 1.19.3 https://youtu.be/K5-NDYFpxnc