### PR TITLE
12.2 - Support for 1.21.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ tasks {
 
 allprojects {
     group = "com.github.kaspiandev.antipopup"
-    version = "12.1"
+    version = "12.2"
 
     repositories {
         mavenCentral()

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 userdevVer=2.0.0-beta.17
 shadowVer=8.1.7
 tinyRemapperVer=0.10.3
-packetEventsVer=2.9.3-SNAPSHOT
+packetEventsVer=2.9.4-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 userdevVer=2.0.0-beta.17
 shadowVer=8.1.7
 tinyRemapperVer=0.10.3
-packetEventsVer=2.9.0-SNAPSHOT
+packetEventsVer=2.9.3-SNAPSHOT

--- a/spigot/src/main/java/com/github/kaspiandev/antipopup/spigot/AntiPopup.java
+++ b/spigot/src/main/java/com/github/kaspiandev/antipopup/spigot/AntiPopup.java
@@ -123,7 +123,7 @@ public final class AntiPopup extends JavaPlugin {
         if (config.isBlockChatReports()) {
             if (!config.isExperimentalMode()) {
                 PlayerListener playerListener = switch (serverManager.getVersion()) {
-                    case V_1_21_6, V_1_21_7 -> new PlayerListener(new PlayerInjector_v1_21_6());
+                    case V_1_21_6, V_1_21_7, V_1_21_8 -> new PlayerListener(new PlayerInjector_v1_21_6());
                     case V_1_21_5 -> new PlayerListener(new PlayerInjector_v1_21_5());
                     case V_1_21_4 -> new PlayerListener(new PlayerInjector_v1_21_4());
                     case V_1_21_2, V_1_21_3 -> new PlayerListener(new PlayerInjector_v1_21_2());


### PR DESCRIPTION
Trying to use version 12.1 of the plugin on 1.21.8 displays the following warn on the console:
`[AntiPopup] [packetevents] We currently do not support the Minecraft version 1.21.8, so things might break. PacketEvents will behave as if the Minecraft version were 1.21.7!`

This PR, solves that by bumping the Packet Events version