### PR TITLE
1.21.11 support (Mojang NMS)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ tasks {
 
 allprojects {
     group = "com.github.kaspiandev.antipopup"
-    version = "12.3"
+    version = "12.4"
 
     repositories {
         mavenCentral()

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 userdevVer=2.0.0-beta.17
 shadowVer=8.1.7
 tinyRemapperVer=0.10.3
-packetEventsVer=2.10.0-SNAPSHOT
+packetEventsVer=2.11.1

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,6 +8,6 @@ pluginManagement {
 rootProject.name = "AntiPopup"
 include "spigot", "shared", "nms", "v1.19.2", "v1.19.3", "v1.19.4",
         "v1.20.1", "v1.20.2", "v1.20.4", "v1.20.6", "v1.21",
-        "v1.21.2", "v1.21.4", "v1.21.5", "v1.21.6", "v1.21.9",
+        "v1.21.2", "v1.21.4", "v1.21.5", "v1.21.6", "v1.21.9", "v1.21.11",
         "velocity"
 

--- a/spigot/build.gradle
+++ b/spigot/build.gradle
@@ -26,6 +26,8 @@ dependencies {
     implementation project(path: ":v1.21.5", configuration: "reobf")
     implementation project(path: ":v1.21.6", configuration: "reobf")
     implementation project(path: ":v1.21.9", configuration: "reobf")
+    compileOnly project(path: ":v1.21.11")
+    implementation project(path: ":v1.21.11", configuration: "default")
 
     compileOnly "org.spigotmc:spigot-api:1.19.4-R0.1-SNAPSHOT"
     compileOnly "com.viaversion:viaversion:5.4.0"
@@ -53,6 +55,12 @@ tasks {
         relocate("net.kyori", "com.github.kaspiandev.antipopup.libs.kyori")
         relocate("org.bstats", "com.github.kaspiandev.antipopup.libs.bstats")
         relocate("com.tcoded.folialib", "com.github.kaspiandev.antipopup.libs.folialib")
+        
+        manifest {
+            attributes([
+                "paperweight-mappings-namespace": "mojang"
+            ])
+        }
     }
 }
 

--- a/spigot/build.gradle
+++ b/spigot/build.gradle
@@ -26,7 +26,6 @@ dependencies {
     implementation project(path: ":v1.21.5", configuration: "reobf")
     implementation project(path: ":v1.21.6", configuration: "reobf")
     implementation project(path: ":v1.21.9", configuration: "reobf")
-    compileOnly project(path: ":v1.21.11")
     implementation project(path: ":v1.21.11", configuration: "default")
 
     compileOnly "org.spigotmc:spigot-api:1.19.4-R0.1-SNAPSHOT"

--- a/spigot/build.gradle
+++ b/spigot/build.gradle
@@ -54,12 +54,6 @@ tasks {
         relocate("net.kyori", "com.github.kaspiandev.antipopup.libs.kyori")
         relocate("org.bstats", "com.github.kaspiandev.antipopup.libs.bstats")
         relocate("com.tcoded.folialib", "com.github.kaspiandev.antipopup.libs.folialib")
-        
-        manifest {
-            attributes([
-                "paperweight-mappings-namespace": "mojang"
-            ])
-        }
     }
 }
 

--- a/spigot/src/main/java/com/github/kaspiandev/antipopup/spigot/AntiPopup.java
+++ b/spigot/src/main/java/com/github/kaspiandev/antipopup/spigot/AntiPopup.java
@@ -17,6 +17,7 @@ import com.github.kaspiandev.antipopup.nms.v1_21_4.PlayerInjector_v1_21_4;
 import com.github.kaspiandev.antipopup.nms.v1_21_5.PlayerInjector_v1_21_5;
 import com.github.kaspiandev.antipopup.nms.v1_21_6.PlayerInjector_v1_21_6;
 import com.github.kaspiandev.antipopup.nms.v1_21_9.PlayerInjector_v1_21_9;
+import com.github.kaspiandev.antipopup.nms.v1_21_11.PlayerInjector_v1_21_11;
 import com.github.kaspiandev.antipopup.spigot.api.Api;
 import com.github.kaspiandev.antipopup.spigot.hook.HookManager;
 import com.github.kaspiandev.antipopup.spigot.hook.viaversion.ViaVersionHook;
@@ -124,6 +125,7 @@ public final class AntiPopup extends JavaPlugin {
         if (config.isBlockChatReports()) {
             if (!config.isExperimentalMode()) {
                 PlayerListener playerListener = switch (serverManager.getVersion()) {
+                    case V_1_21_11 -> new PlayerListener(new PlayerInjector_v1_21_11());
                     case V_1_21_9, V_1_21_10 -> new PlayerListener(new PlayerInjector_v1_21_9());
                     case V_1_21_6, V_1_21_7, V_1_21_8 -> new PlayerListener(new PlayerInjector_v1_21_6());
                     case V_1_21_5 -> new PlayerListener(new PlayerInjector_v1_21_5());

--- a/v1.21.11/build.gradle
+++ b/v1.21.11/build.gradle
@@ -1,0 +1,31 @@
+plugins {
+    id "java"
+    id "io.papermc.paperweight.userdev" version "${userdevVer}"
+}
+
+dependencies {
+    compileOnly project(path: ":shared")
+    compileOnly project(path: ":nms")
+
+    paperweightDevelopmentBundle "io.papermc.paper:dev-bundle:1.21.11-R0.1-SNAPSHOT"
+}
+
+java {
+    disableAutoTargetJvm()
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(21))
+    }
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+// Configure jar manifest to indicate Mojang mappings
+// This tells Paper that the plugin is already Mojang-mapped and doesn't need reobf
+tasks.named("jar") {
+    manifest {
+        attributes([
+            "paperweight-mappings-namespace": "mojang"
+        ])
+    }
+}
+

--- a/v1.21.11/src/main/java/com/github/kaspiandev/antipopup/nms/v1_21_11/PlayerInjector_v1_21_11.java
+++ b/v1.21.11/src/main/java/com/github/kaspiandev/antipopup/nms/v1_21_11/PlayerInjector_v1_21_11.java
@@ -1,0 +1,87 @@
+package com.github.kaspiandev.antipopup.nms.v1_21_11;
+
+import com.github.kaspiandev.antipopup.spigot.nms.PacketInjector;
+import io.netty.channel.*;
+import net.minecraft.network.Connection;
+import net.minecraft.network.chat.ChatType;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.protocol.game.ClientboundPlayerChatPacket;
+import net.minecraft.network.protocol.game.ClientboundSystemChatPacket;
+import net.minecraft.server.network.ServerCommonPacketListenerImpl;
+import net.minecraft.server.network.ServerGamePacketListenerImpl;
+import org.bukkit.craftbukkit.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InaccessibleObjectException;
+
+@SuppressWarnings("unused")
+public class PlayerInjector_v1_21_11 implements PacketInjector {
+
+    private static final String HANDLER_NAME = "antipopup_handler";
+    private static Field connectionField;
+
+    static {
+        try {
+            for (Field field : ServerCommonPacketListenerImpl.class.getDeclaredFields()) {
+                if (field.getType().equals(Connection.class)) {
+                    field.setAccessible(true);
+                    connectionField = field;
+                    break;
+                }
+            }
+        } catch (SecurityException | InaccessibleObjectException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void inject(Player player) {
+        ChannelDuplexHandler duplexHandler = new ChannelDuplexHandler() {
+            @Override
+            public void write(ChannelHandlerContext ctx, Object packet, ChannelPromise promise) throws Exception {
+                if (packet instanceof ClientboundPlayerChatPacket chatPacket) {
+                    Component content = chatPacket.unsignedContent();
+                    if (content == null) {
+                        content = Component.literal(chatPacket.body().content());
+                    }
+                    ChatType.Bound chatType = chatPacket.chatType();
+
+                    ((CraftPlayer) player).getHandle().connection.send(
+                            new ClientboundSystemChatPacket(chatType.decorate(content), false));
+                    return;
+                }
+                super.write(ctx, packet, promise);
+            }
+        };
+
+        ServerGamePacketListenerImpl listener = ((CraftPlayer) player).getHandle().connection;
+        Channel channel = getConnection(listener).channel;
+        ChannelPipeline pipeline = channel.pipeline();
+
+        if (pipeline.get(HANDLER_NAME) != null) {
+            pipeline.remove(HANDLER_NAME);
+        }
+
+        channel.eventLoop().submit(() -> {
+            channel.pipeline().addBefore("packet_handler", HANDLER_NAME, duplexHandler);
+        });
+    }
+
+    public void uninject(Player player) {
+        ServerGamePacketListenerImpl listener = ((CraftPlayer) player).getHandle().connection;
+        Channel channel = getConnection(listener).channel;
+        channel.eventLoop().submit(() -> {
+            channel.pipeline().remove(HANDLER_NAME);
+        });
+    }
+
+    private Connection getConnection(ServerGamePacketListenerImpl listener) {
+        try {
+            return (Connection) connectionField.get(listener);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}
+


### PR DESCRIPTION
The biggest obstacle in the way of supporting version 1.21.11 (and especially 26.1 onward) is the plugin's use of Spigot mappings (reobfuscation) instead of Mojang's proprietary mapped classes.  This is confirmed by https://github.com/PaperMC/Paper/pull/13388#issuecomment-3648574532 which states that "[plugins] have to be on mojang mappings for the next release anyway as 26.1 will be on mojang mappings for both spigot *and* paper."


As @KaspianDev states in #127, the Spigot API is currently what's delaying support for the new version, and so this PR replaces the Spigot NMS with that of Mojang for version 1.21.11.  Spigot reobfuscation continues to be used for game versions 1.21.10 and earlier, **meaning that backwards compatibility is preserved.**

```
icanhasbukkit
[23:02:13 INFO]: Checking version, please wait...
[23:02:13 INFO]: This server is running Paper version 1.21.11-51-main@90191f7 (2025-12-21T22:07:10Z) (Implementing API version 1.21.11-R0.1-SNAPSHOT)
You are running the latest version
Previous version: 1.21.10-89-c7714bb (MC: 1.21.10)
version AntiPopup
[23:02:17 INFO]: AntiPopup version 12.3
A plugin that removed annoying unsafe server popup.
Author: Kaspian
```