### PR TITLE
13.2 - version 26.2 support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ tasks {
 
 allprojects {
     group = "com.github.kaspiandev.antipopup"
-    version = "13.1"
+    version = "13.2"
 
     repositories {
         mavenCentral()

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 userdevVer=2.0.0-beta.21
 shadowVer=9.4.1
 tinyRemapperVer=0.10.3
-packetEventsVer=2.12.1-SNAPSHOT
+packetEventsVer=2.13.1-SNAPSHOT

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,5 +9,5 @@ rootProject.name = "AntiPopup"
 include "spigot", "shared", "nms", "v1.19.2", "v1.19.3", "v1.19.4",
         "v1.20.1", "v1.20.2", "v1.20.4", "v1.20.6", "v1.21",
         "v1.21.2", "v1.21.4", "v1.21.5", "v1.21.6", "v1.21.9", "v1.21.11",
-        "v26.1", "velocity"
+        "v26.1", "v26.2", "velocity"
 

--- a/spigot/build.gradle
+++ b/spigot/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation project(path: ":v1.21.9", configuration: "reobf")
     implementation project(path: ":v1.21.11", configuration: "reobf")
     implementation project(path: ":v26.1", configuration: "default")
+    implementation project(path: ":v26.2", configuration: "default")
 
     compileOnly "org.spigotmc:spigot-api:1.19.4-R0.1-SNAPSHOT"
     compileOnly "com.viaversion:viaversion:5.4.0"

--- a/spigot/src/main/java/com/github/kaspiandev/antipopup/spigot/AntiPopup.java
+++ b/spigot/src/main/java/com/github/kaspiandev/antipopup/spigot/AntiPopup.java
@@ -19,6 +19,7 @@ import com.github.kaspiandev.antipopup.nms.v1_21_6.PlayerInjector_v1_21_6;
 import com.github.kaspiandev.antipopup.nms.v1_21_9.PlayerInjector_v1_21_9;
 import com.github.kaspiandev.antipopup.nms.v1_21_11.PlayerInjector_v1_21_11;
 import com.github.kaspiandev.antipopup.nms.v26_1.PlayerInjector_v26_1;
+import com.github.kaspiandev.antipopup.nms.v26_2.PlayerInjector_v26_2;
 import com.github.kaspiandev.antipopup.spigot.api.Api;
 import com.github.kaspiandev.antipopup.spigot.hook.HookManager;
 import com.github.kaspiandev.antipopup.spigot.hook.viaversion.ViaVersionHook;
@@ -126,6 +127,7 @@ public final class AntiPopup extends JavaPlugin {
         if (config.isBlockChatReports()) {
             if (!config.isExperimentalMode()) {
                 PlayerListener playerListener = switch (serverManager.getVersion()) {
+                    case V_26_2 -> new PlayerListener(new PlayerInjector_v26_2());
                     case V_26_1, V_26_1_1, V_26_1_2 -> new PlayerListener(new PlayerInjector_v26_1());
                     case V_1_21_11 -> new PlayerListener(new PlayerInjector_v1_21_11());
                     case V_1_21_9, V_1_21_10 -> new PlayerListener(new PlayerInjector_v1_21_9());

--- a/v26.2/build.gradle
+++ b/v26.2/build.gradle
@@ -1,0 +1,20 @@
+plugins {
+    id "java"
+    id "io.papermc.paperweight.userdev" version "${userdevVer}"
+}
+
+dependencies {
+    compileOnly project(path: ":shared")
+    compileOnly project(path: ":nms")
+
+    paperweightDevelopmentBundle "io.papermc.paper:dev-bundle:26.2.build.34-alpha"
+}
+
+java {
+    disableAutoTargetJvm()
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(25))
+    }
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}

--- a/v26.2/src/main/java/com/github/kaspiandev/antipopup/nms/v26_2/PlayerInjector_v26_2.java
+++ b/v26.2/src/main/java/com/github/kaspiandev/antipopup/nms/v26_2/PlayerInjector_v26_2.java
@@ -1,0 +1,87 @@
+package com.github.kaspiandev.antipopup.nms.v26_2;
+
+import com.github.kaspiandev.antipopup.spigot.nms.PacketInjector;
+import io.netty.channel.*;
+import net.minecraft.network.Connection;
+import net.minecraft.network.chat.ChatType;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.protocol.game.ClientboundPlayerChatPacket;
+import net.minecraft.network.protocol.game.ClientboundSystemChatPacket;
+import net.minecraft.server.network.ServerCommonPacketListenerImpl;
+import net.minecraft.server.network.ServerGamePacketListenerImpl;
+import org.bukkit.craftbukkit.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InaccessibleObjectException;
+
+@SuppressWarnings("unused")
+public class PlayerInjector_v26_2 implements PacketInjector {
+
+    private static final String HANDLER_NAME = "antipopup_handler";
+    private static Field connectionField;
+
+    static {
+        try {
+            for (Field field : ServerCommonPacketListenerImpl.class.getDeclaredFields()) {
+                if (field.getType().equals(Connection.class)) {
+                    field.setAccessible(true);
+                    connectionField = field;
+                    break;
+                }
+            }
+        } catch (SecurityException | InaccessibleObjectException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void inject(Player player) {
+        ChannelDuplexHandler duplexHandler = new ChannelDuplexHandler() {
+            @Override
+            public void write(ChannelHandlerContext ctx, Object packet, ChannelPromise promise) throws Exception {
+                if (packet instanceof ClientboundPlayerChatPacket chatPacket) {
+                    Component content = chatPacket.unsignedContent();
+                    if (content == null) {
+                        content = Component.literal(chatPacket.body().content());
+                    }
+                    ChatType.Bound chatType = chatPacket.chatType();
+
+                    ((CraftPlayer) player).getHandle().connection.send(
+                            new ClientboundSystemChatPacket(chatType.decorate(content), false));
+                    return;
+                }
+                super.write(ctx, packet, promise);
+            }
+        };
+
+        ServerGamePacketListenerImpl listener = ((CraftPlayer) player).getHandle().connection;
+        Channel channel = getConnection(listener).channel;
+        ChannelPipeline pipeline = channel.pipeline();
+
+        if (pipeline.get(HANDLER_NAME) != null) {
+            pipeline.remove(HANDLER_NAME);
+        }
+
+        channel.eventLoop().submit(() -> {
+            channel.pipeline().addBefore("packet_handler", HANDLER_NAME, duplexHandler);
+        });
+    }
+
+    public void uninject(Player player) {
+        ServerGamePacketListenerImpl listener = ((CraftPlayer) player).getHandle().connection;
+        Channel channel = getConnection(listener).channel;
+        channel.eventLoop().submit(() -> {
+            channel.pipeline().remove(HANDLER_NAME);
+        });
+    }
+
+    private Connection getConnection(ServerGamePacketListenerImpl listener) {
+        try {
+            return (Connection) connectionField.get(listener);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}
+


### PR DESCRIPTION
This patch adds support for 26.2, bumps PacketEvents to 2.13.1, and bumps the plugin version to 13.2.